### PR TITLE
feat: add deterministic demo simulation mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           cache-dependency-path: backend/requirements.txt
       - name: Install dependencies
         run: python -m pip install -r backend/requirements.txt
+      - name: Run backend tests
+        run: python -m unittest discover -s tests -v
       - name: Compile backend
         run: python -m compileall -q backend dev_runner.py
       - name: Validate NAS compose configuration

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ cd frontend && npm install && npm run dev
 
 Open `http://localhost:5173` (or the port shown by Vite) in your browser.
 
+### Demo mode without Ollama/PostgreSQL/ChromaDB
+
+To quickly generate deterministic sandbox state without external services:
+
+```bash
+python3 backend/simulation.py --demo --seed 42 --turns 10 --sleep 0
+```
+
+This writes `backend/static/sandbox_state.json`, which the frontend can display through the backend API once the API server is running. Use the same `--seed` value to reproduce the same demo run.
+
+Useful options:
+
+```bash
+python3 backend/simulation.py --demo --seed 7 --turns 100 --agents 8 --sleep 0.1
+```
+
 ---
 
 ## How It Works

--- a/backend/demo_runtime.py
+++ b/backend/demo_runtime.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import random
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, List
+
+
+@dataclass
+class DemoMemoryItem:
+    content: str
+    importance: float
+    timestamp: int
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    entropy_level: float = 0.0
+
+
+class DemoMemorySystem:
+    """In-memory memory backend for deterministic demos and tests."""
+
+    def __init__(self, agent_id: str):
+        self.agent_id = agent_id
+        self.short_term: List[DemoMemoryItem] = []
+
+    def add_memory(self, content: str, importance: float, timestamp: int):
+        self.short_term.append(
+            DemoMemoryItem(content=content, importance=importance, timestamp=timestamp)
+        )
+
+    def reflect_and_summarize(self, current_time: int) -> List[DemoMemoryItem]:
+        reflected = [mem for mem in self.short_term if mem.importance >= 0.5]
+        self.short_term = []
+        return reflected
+
+    def retrieve_relevant(self, query: str, top_k: int = 5) -> list[Any]:
+        return []
+
+
+class DemoLLMRouter:
+    """Deterministic LLM stand-in for local demos without Ollama."""
+
+    def __init__(self, seed: int | None = None):
+        self.random = random.Random(seed)
+        self.actions = [
+            "[DEMO] gathers bright berries near the river and shares them by the fire.",
+            "[DEMO] sketches a spiral mark on a flat stone after watching the stars.",
+            "[DEMO] follows deer tracks into the forest and returns with a strange feather.",
+            "[DEMO] repairs a fishing net while humming an old rhythm.",
+            "[DEMO] tells the children that the wind has a hidden name.",
+        ]
+        self.reflections = [
+            "[DEMO] The villagers remember the river as generous and name it the Silver Mother.",
+            "[DEMO] The spiral stone becomes an omen of safe return from the dark forest.",
+            "[DEMO] The feather is said to belong to a sky spirit watching the village.",
+        ]
+
+    def chat_daily(self, prompt: str) -> str:
+        agent_name = _extract_agent_name(prompt)
+        action = self.random.choice(self.actions)
+        return f"{agent_name} {action}"
+
+    def reflect_and_hallucinate(self, memories: list[Any], entropy_factor: float) -> str:
+        reflection = self.random.choice(self.reflections)
+        memory_texts = []
+        for memory in memories:
+            if hasattr(memory, "content"):
+                memory_texts.append(str(memory.content))
+            elif isinstance(memory, str):
+                memory_texts.append(memory)
+        if memory_texts:
+            return f"{reflection} Echo: {memory_texts[-1]}"
+        return reflection
+
+    def extract_vector(self, text: str) -> list[float]:
+        return [self.random.uniform(-1, 1) for _ in range(3)]
+
+
+def _extract_agent_name(prompt: str) -> str:
+    match = re.search(r"Agent-\d+", prompt)
+    return match.group(0) if match else "Agent"

--- a/backend/simulation.py
+++ b/backend/simulation.py
@@ -1,37 +1,69 @@
-from agent import Agent
-from memory import MemorySystem
-from llm_router import LLMRouter
-from database import SessionLocal, engine, Base
-from epoch_detector import detect_and_record_epoch
-from chronicle_summarizer import generate_chronicle
-import models
+from __future__ import annotations
+
+import argparse
 import json
 import os
 import random
+import time
+from typing import Optional
+
+from agent import Agent
+from demo_runtime import DemoLLMRouter, DemoMemorySystem
 from sandbox_utils import parse_agent_action
 
-# Ensure tables are created
-Base.metadata.create_all(bind=engine)
 
 class Simulation:
-    def __init__(self, num_agents: int = 5):
-        self.router = LLMRouter()
+    def __init__(self, num_agents: int = 5, demo_mode: bool = False, seed: Optional[int] = None):
+        self.demo_mode = demo_mode
+        self.random = random.Random(seed)
+        self.demo_events = []
+        self._models = None
+        self._SessionLocal = None
+        self._detect_and_record_epoch = None
+        self._generate_chronicle = None
+
+        if demo_mode:
+            self.router = DemoLLMRouter(seed=seed)
+            memory_factory = DemoMemorySystem
+            print(f"[Simulation] Starting demo mode with seed={seed}.")
+        else:
+            from database import SessionLocal, engine, Base
+            from epoch_detector import detect_and_record_epoch
+            from chronicle_summarizer import generate_chronicle
+            from llm_router import LLMRouter
+            from memory import MemorySystem
+            import models
+
+            # Ensure tables are created only for real DB-backed runs.
+            Base.metadata.create_all(bind=engine)
+            self._SessionLocal = SessionLocal
+            self._models = models
+            self._detect_and_record_epoch = detect_and_record_epoch
+            self._generate_chronicle = generate_chronicle
+            self.router = LLMRouter()
+            memory_factory = MemorySystem
+
         self.agents = [Agent(f"Agent-{i}", "Curious pioneer") for i in range(num_agents)]
+        if demo_mode:
+            for i, agent in enumerate(self.agents):
+                agent.identity.agent_id = f"demo-agent-{i}"
 
         # Inject memory system into agents
         for a in self.agents:
-            a.memory = MemorySystem(agent_id=a.identity.agent_id)
+            a.memory = memory_factory(agent_id=a.identity.agent_id)
 
-        # Fix #2: Resume from the last turn stored in the DB
-        self.turn = self._resume_turn()
+        self.turn = 0 if demo_mode else self._resume_turn()
         print(f"[Simulation] Resuming from turn {self.turn}.")
 
     def _resume_turn(self) -> int:
         """Read the last persisted turn from the DB to enable seamless restart."""
-        db = SessionLocal()
+        if self.demo_mode or self._SessionLocal is None or self._models is None:
+            return 0
+
+        db = self._SessionLocal()
         try:
-            last_event = db.query(models.SimulationEvent).order_by(
-                models.SimulationEvent.turn.desc()
+            last_event = db.query(self._models.SimulationEvent).order_by(
+                self._models.SimulationEvent.turn.desc()
             ).first()
             if last_event:
                 return int(last_event.turn) + 1
@@ -42,69 +74,73 @@ class Simulation:
         finally:
             db.close()
 
-
     def step(self):
         """Execute one full turn in the simulation (e.g., 1 Day)"""
         print(f"--- Turn {self.turn} ---")
 
-        db = SessionLocal()
-        try:
-            # 1. Daily Actions (Local LLM Routing)
-            for agent in self.agents:
-                action = self.router.chat_daily(f"What will {agent.identity.name} do?")
+        if self.demo_mode:
+            self._step_without_db()
+        else:
+            self._step_with_db()
 
-                if not action or "[FALLBACK]" in action:
-                    print(f"[WARN] Agent {agent.identity.name} got a fallback response at turn {self.turn}. Skipping save.")
+        # Output current state for Sandbox View
+        self._dump_sandbox_state()
+
+        self.turn += 1
+
+    def _step_without_db(self):
+        for agent in self.agents:
+            action = self._run_daily_action(agent)
+            if action:
+                self.demo_events.append({
+                    "turn": self.turn,
+                    "agent_id": agent.identity.agent_id,
+                    "event_type": "DAILY_ACTION",
+                    "content": action,
+                })
+
+        if self.turn % 5 == 0 and self.turn > 0:
+            print(">>> The agents are reflecting... (Entropy Injection)")
+            for agent in self.agents:
+                reflection = self._run_reflection(agent)
+                if reflection:
+                    self.demo_events.append({
+                        "turn": self.turn,
+                        "agent_id": agent.identity.agent_id,
+                        "event_type": "REFLECTION",
+                        "content": reflection,
+                    })
+
+    def _step_with_db(self):
+        db = self._SessionLocal()
+        try:
+            for agent in self.agents:
+                action = self._run_daily_action(agent)
+                if not action:
                     continue
 
-                agent.memory.add_memory(action, importance=0.5, timestamp=self.turn)
-
-                # --- Sandbox State Update ---
-                parsed = parse_agent_action(action)
-                agent.state.emotion = parsed["emotion"]
-                agent.state.current_action = parsed["action"]
-                agent.state.speech = parsed["speech"]
-                # Move slightly
-                agent.state.x = max(0.0, min(100.0, agent.state.x + random.uniform(-10.0, 10.0)))
-                agent.state.y = max(0.0, min(100.0, agent.state.y + random.uniform(-10.0, 10.0)))
-
-                # Save Daily Action to DB
-                event = models.SimulationEvent(
+                event = self._models.SimulationEvent(
                     turn=self.turn,
                     agent_id=agent.identity.agent_id,
                     event_type="DAILY_ACTION",
-                    content=action
+                    content=action,
                 )
                 db.add(event)
 
-            # 2. Nightly Reflection & Entropy Injection (Cloud LLM Routing)
-            # Occurs every 5 turns
             if self.turn % 5 == 0 and self.turn > 0:
                 print(">>> The agents are reflecting... (Entropy Injection)")
                 for agent in self.agents:
-                    summarized = agent.memory.reflect_and_summarize(current_time=self.turn)
-                    exaggerated_memory = self.router.reflect_and_hallucinate(summarized, entropy_factor=0.3)
-
-                    if not exaggerated_memory or "[FALLBACK]" in exaggerated_memory:
-                        print(f"[WARN] Reflection fallback for {agent.identity.name} at turn {self.turn}. Skipping.")
+                    reflection = self._run_reflection(agent)
+                    if not reflection:
                         continue
 
-                    # Save Reflection to DB
-                    event = models.SimulationEvent(
+                    event = self._models.SimulationEvent(
                         turn=self.turn,
                         agent_id=agent.identity.agent_id,
                         event_type="REFLECTION",
-                        content=exaggerated_memory
+                        content=reflection,
                     )
                     db.add(event)
-
-                    # Save embedding vector to ChromaDB memory
-                    vec = self.router.extract_vector(exaggerated_memory)
-                    agent.memory.add_memory(
-                        f"[LEGEND] {exaggerated_memory}",
-                        importance=0.9,
-                        timestamp=self.turn
-                    )
 
             db.commit()
         except Exception as e:
@@ -114,15 +150,46 @@ class Simulation:
             db.close()
 
         # Phase 5: Auto-detect and record new epochs every N turns
-        detect_and_record_epoch(self.turn)
+        self._detect_and_record_epoch(self.turn)
 
         # Phase 5: Generate chronicle summary every 100 turns
-        generate_chronicle(self.turn)
+        self._generate_chronicle(self.turn)
 
-        # Output current state for Sandbox View
-        self._dump_sandbox_state()
+    def _run_daily_action(self, agent: Agent) -> str | None:
+        action = self.router.chat_daily(f"What will {agent.identity.name} do?")
 
-        self.turn += 1
+        if not action or "[FALLBACK]" in action:
+            print(f"[WARN] Agent {agent.identity.name} got a fallback response at turn {self.turn}. Skipping save.")
+            return None
+
+        agent.memory.add_memory(action, importance=0.5, timestamp=self.turn)
+
+        # --- Sandbox State Update ---
+        parsed = parse_agent_action(action)
+        agent.state.emotion = parsed["emotion"]
+        agent.state.current_action = parsed["action"]
+        agent.state.speech = parsed["speech"]
+        # Move slightly; seeded RNG makes demo mode reproducible.
+        agent.state.x = max(0.0, min(100.0, agent.state.x + self.random.uniform(-10.0, 10.0)))
+        agent.state.y = max(0.0, min(100.0, agent.state.y + self.random.uniform(-10.0, 10.0)))
+        return action
+
+    def _run_reflection(self, agent: Agent) -> str | None:
+        summarized = agent.memory.reflect_and_summarize(current_time=self.turn)
+        exaggerated_memory = self.router.reflect_and_hallucinate(summarized, entropy_factor=0.3)
+
+        if not exaggerated_memory or "[FALLBACK]" in exaggerated_memory:
+            print(f"[WARN] Reflection fallback for {agent.identity.name} at turn {self.turn}. Skipping.")
+            return None
+
+        # Save embedding vector to ChromaDB memory in real mode; demo memory ignores this as short-term lore.
+        self.router.extract_vector(exaggerated_memory)
+        agent.memory.add_memory(
+            f"[LEGEND] {exaggerated_memory}",
+            importance=0.9,
+            timestamp=self.turn,
+        )
+        return exaggerated_memory
 
     def _dump_sandbox_state(self):
         state_data = []
@@ -134,9 +201,9 @@ class Simulation:
                 "y": agent.state.y,
                 "emotion": agent.state.emotion,
                 "action": agent.state.current_action,
-                "speech": agent.state.speech
+                "speech": agent.state.speech,
             })
-        
+
         static_dir = os.path.join(os.path.dirname(__file__), "static")
         os.makedirs(static_dir, exist_ok=True)
         try:
@@ -145,13 +212,36 @@ class Simulation:
         except Exception as e:
             print(f"[WARN] Failed to write sandbox state: {e}")
 
-if __name__ == "__main__":
-    import time
-    sim = Simulation(num_agents=5)
-    print("Starting continuous simulation... Press Ctrl+C to stop.")
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Entropy Civil simulation.")
+    parser.add_argument("--demo", action="store_true", help="Run without Ollama/PostgreSQL/ChromaDB using deterministic demo data.")
+    parser.add_argument("--seed", type=int, default=None, help="Seed for deterministic demo/sandbox movement.")
+    parser.add_argument("--turns", type=int, default=None, help="Run a fixed number of turns, then exit.")
+    parser.add_argument("--sleep", type=float, default=2.0, help="Seconds to wait between turns.")
+    parser.add_argument("--agents", type=int, default=5, help="Number of agents to simulate.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    sim = Simulation(num_agents=args.agents, demo_mode=args.demo, seed=args.seed)
+    mode = "demo" if args.demo else "continuous"
+    if args.turns is None:
+        print(f"Starting {mode} simulation... Press Ctrl+C to stop.")
+    else:
+        print(f"Starting {mode} simulation for {args.turns} turns...")
+
     try:
-        while True:
+        turns_run = 0
+        while args.turns is None or turns_run < args.turns:
             sim.step()
-            time.sleep(2)  # Wait 2 seconds between turns for readability
+            turns_run += 1
+            if args.turns is None or turns_run < args.turns:
+                time.sleep(args.sleep)
     except KeyboardInterrupt:
         print("Simulation paused.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_runtime.py
+++ b/tests/test_demo_runtime.py
@@ -1,0 +1,29 @@
+import unittest
+
+from backend.demo_runtime import DemoLLMRouter, DemoMemorySystem
+
+
+class DemoRuntimeTest(unittest.TestCase):
+    def test_demo_router_is_deterministic_for_same_seed(self):
+        first = DemoLLMRouter(seed=42)
+        second = DemoLLMRouter(seed=42)
+
+        first_actions = [first.chat_daily("What will Agent-0 do?") for _ in range(4)]
+        second_actions = [second.chat_daily("What will Agent-0 do?") for _ in range(4)]
+
+        self.assertEqual(first_actions, second_actions)
+        self.assertTrue(all("[DEMO]" in action for action in first_actions))
+
+    def test_demo_memory_reflects_and_clears_short_term_memories(self):
+        memory = DemoMemorySystem(agent_id="agent-1")
+        memory.add_memory("Agent gathered berries.", importance=0.5, timestamp=3)
+
+        reflected = memory.reflect_and_summarize(current_time=5)
+
+        self.assertEqual(len(reflected), 1)
+        self.assertEqual(reflected[0].content, "Agent gathered berries.")
+        self.assertEqual(memory.short_term, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_demo_simulation_cli.py
+++ b/tests/test_demo_simulation_cli.py
@@ -1,0 +1,70 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class DemoSimulationCliTest(unittest.TestCase):
+    def test_demo_cli_runs_fixed_number_of_turns_without_service_dependencies(self):
+        repo = Path(__file__).resolve().parents[1]
+        state_file = repo / "backend" / "static" / "sandbox_state.json"
+        if state_file.exists():
+            state_file.unlink()
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(repo / "backend" / "simulation.py"),
+                "--demo",
+                "--seed",
+                "7",
+                "--turns",
+                "2",
+                "--sleep",
+                "0",
+            ],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("Starting demo simulation", result.stdout)
+        self.assertTrue(state_file.exists())
+        state = json.loads(state_file.read_text())
+        self.assertEqual(state["turn"], 1)
+        self.assertEqual(len(state["agents"]), 5)
+
+    def test_demo_cli_reproduces_same_sandbox_state_for_same_seed(self):
+        repo = Path(__file__).resolve().parents[1]
+        state_file = repo / "backend" / "static" / "sandbox_state.json"
+
+        states = []
+        for _ in range(2):
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(repo / "backend" / "simulation.py"),
+                    "--demo",
+                    "--seed",
+                    "11",
+                    "--turns",
+                    "3",
+                    "--sleep",
+                    "0",
+                ],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            states.append(json.loads(state_file.read_text()))
+
+        self.assertEqual(states[0], states[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / なぜこの変更が必要か

Slack に残していた初期戦略のうち、次の優先項目は「demo mode / seeded simulation」です。

現状の Entropy Civil は Ollama / PostgreSQL / ChromaDB が揃っている前提が強く、第三者が clone してすぐに雰囲気を確認するには少し重い状態です。また、simulation が毎回ランダムだと README 用の例・CI smoke test・デバッグで同じ結果を再現しづらい問題があります。

この PR では、外部サービスが無い環境でも deterministic な sandbox state を生成できる demo mode を追加し、今後の Public Demo 化の土台を作ります。

Closes #3

## What / 何を変更したか

### demo runtime の追加

- `backend/demo_runtime.py` を追加しました。
- Ollama の代わりに deterministic な文章を返す `DemoLLMRouter` を追加しました。
- ChromaDB の代わりに in-memory で動く `DemoMemorySystem` を追加しました。

### simulation CLI の拡張

`backend/simulation.py` に CLI option を追加しました。

- `--demo`: Ollama / PostgreSQL / ChromaDB なしで demo runtime を使う
- `--seed`: deterministic run 用 seed
- `--turns`: 指定 turn 数だけ実行して終了
- `--sleep`: turn 間の sleep 秒数
- `--agents`: agent 数

例:

```bash
python3 backend/simulation.py --demo --seed 42 --turns 10 --sleep 0
```

### deterministic sandbox state

- demo mode では agent id を `demo-agent-{n}` に固定しました。
- 同じ `--seed` と `--turns` なら同じ `backend/static/sandbox_state.json` が生成されます。
- demo mode では DB table 作成や LLM/ChromaDB import を遅延させ、外部 service dependency なしで CLI が動くようにしました。

### test / CI

- `tests/test_demo_runtime.py` を追加しました。
- `tests/test_demo_simulation_cli.py` を追加しました。
- CI backend job で `python -m unittest discover -s tests -v` を実行するようにしました。

### README

- demo mode の実行手順を README に追加しました。

## 検証内容

ローカルで以下を確認済みです。

- [x] `python3 -m unittest discover -s tests -v`
- [x] `python3 -m compileall -q backend dev_runner.py`
- [x] `python3 backend/simulation.py --demo --seed 42 --turns 2 --sleep 0`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`

## 備考

この PR は demo mode の第一歩です。次の段階では、生成した demo state を API / frontend からより直接体験できるようにし、README に screenshot/GIF を追加していく想定です。
