### PR TITLE
feat: World State / Locations / Resources を導入

### DIFF
--- a/backend/simulation.py
+++ b/backend/simulation.py
@@ -10,12 +10,15 @@ from typing import Optional
 from agent import Agent
 from demo_runtime import DemoLLMRouter, DemoMemorySystem
 from sandbox_utils import parse_agent_action
+from world_state import WorldState, apply_agent_action_to_world
 
 
 class Simulation:
     def __init__(self, num_agents: int = 5, demo_mode: bool = False, seed: Optional[int] = None):
         self.demo_mode = demo_mode
         self.random = random.Random(seed)
+        self.world = WorldState.create_default(self.random)
+        self.agent_locations: dict[str, str] = {}
         self.demo_events = []
         self._models = None
         self._SessionLocal = None
@@ -163,15 +166,23 @@ class Simulation:
             return None
 
         agent.memory.add_memory(action, importance=0.5, timestamp=self.turn)
+        world_event = apply_agent_action_to_world(
+            self.world,
+            agent.identity.agent_id,
+            action,
+            self.random,
+        )
+        self.agent_locations[agent.identity.agent_id] = world_event["location_id"]
 
         # --- Sandbox State Update ---
         parsed = parse_agent_action(action)
         agent.state.emotion = parsed["emotion"]
         agent.state.current_action = parsed["action"]
         agent.state.speech = parsed["speech"]
-        # Move slightly; seeded RNG makes demo mode reproducible.
-        agent.state.x = max(0.0, min(100.0, agent.state.x + self.random.uniform(-10.0, 10.0)))
-        agent.state.y = max(0.0, min(100.0, agent.state.y + self.random.uniform(-10.0, 10.0)))
+        # Move toward the location affected by this action; seeded RNG keeps demo mode reproducible.
+        location = self.world.locations[world_event["location_id"]]
+        agent.state.x = max(0.0, min(100.0, location.x + self.random.uniform(-5.0, 5.0)))
+        agent.state.y = max(0.0, min(100.0, location.y + self.random.uniform(-5.0, 5.0)))
         return action
 
     def _run_reflection(self, agent: Agent) -> str | None:
@@ -202,13 +213,18 @@ class Simulation:
                 "emotion": agent.state.emotion,
                 "action": agent.state.current_action,
                 "speech": agent.state.speech,
+                "location_id": self.agent_locations.get(agent.identity.agent_id),
             })
 
         static_dir = os.path.join(os.path.dirname(__file__), "static")
         os.makedirs(static_dir, exist_ok=True)
         try:
             with open(os.path.join(static_dir, "sandbox_state.json"), "w", encoding="utf-8") as f:
-                json.dump({"turn": self.turn, "agents": state_data}, f, ensure_ascii=False)
+                json.dump(
+                    {"turn": self.turn, "agents": state_data, "world": self.world.to_dict()},
+                    f,
+                    ensure_ascii=False,
+                )
         except Exception as e:
             print(f"[WARN] Failed to write sandbox state: {e}")
 

--- a/backend/world_state.py
+++ b/backend/world_state.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Location:
+    """A deterministic place in the sandbox civilization map."""
+
+    id: str
+    name: str
+    x: float
+    y: float
+    biome: str
+    resources: list[str]
+    activity: int = 0
+    last_event: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "x": self.x,
+            "y": self.y,
+            "biome": self.biome,
+            "resources": list(self.resources),
+            "activity": self.activity,
+            "last_event": self.last_event,
+        }
+
+
+@dataclass
+class WorldState:
+    """Mutable world state that makes agent actions affect civilization context."""
+
+    weather: str
+    resources: dict[str, int]
+    locations: dict[str, Location] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def create_default(cls, rng: random.Random | None = None) -> "WorldState":
+        rng = rng or random.Random()
+        weather = rng.choice(["clear", "windy", "misty", "rainy"])
+        return cls(
+            weather=weather,
+            resources={
+                "food": 20,
+                "wood": 12,
+                "stone": 8,
+                "fish": 6,
+                "lore": 0,
+            },
+            locations={
+                "river": Location("river", "Silver River", 18.0, 66.0, "water", ["fish", "food"]),
+                "forest": Location("forest", "Deep Forest", 76.0, 30.0, "forest", ["wood", "food"]),
+                "fire_pit": Location("fire_pit", "Central Fire Pit", 50.0, 52.0, "settlement", ["lore"]),
+                "cave": Location("cave", "Echo Cave", 18.0, 22.0, "stone", ["stone", "lore"]),
+                "meadow": Location("meadow", "Open Meadow", 72.0, 72.0, "grassland", ["food"]),
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "weather": self.weather,
+            "resources": dict(self.resources),
+            "locations": [location.to_dict() for location in self.locations.values()],
+            "events": list(self.events[-25:]),
+        }
+
+
+def apply_agent_action_to_world(
+    world: WorldState,
+    agent_id: str,
+    action: str,
+    rng: random.Random | None = None,
+) -> dict[str, Any]:
+    """Apply a simple deterministic resource/location effect from an agent action."""
+
+    rng = rng or random.Random()
+    lowered = action.lower()
+    location_id = _infer_location_id(lowered)
+    resource_id, effect = _infer_resource_effect(lowered)
+    amount = rng.randint(1, 3)
+
+    if effect == "increase":
+        world.resources[resource_id] = world.resources.get(resource_id, 0) + amount
+    elif effect == "decrease":
+        world.resources[resource_id] = max(0, world.resources.get(resource_id, 0) - amount)
+    else:
+        amount = 0
+
+    location = world.locations[location_id]
+    location.activity += 1
+
+    event = {
+        "agent_id": agent_id,
+        "location_id": location_id,
+        "resource_id": resource_id,
+        "effect": effect,
+        "amount": amount,
+        "description": _describe_world_event(agent_id, location_id, resource_id, effect, amount),
+    }
+    location.last_event = event["description"]
+    world.events.append(event)
+    return event
+
+
+def _infer_location_id(action: str) -> str:
+    location_keywords = [
+        ("river", ["river", "fish", "fishing", "net"]),
+        ("forest", ["forest", "deer", "feather", "wood", "tree"]),
+        ("fire_pit", ["fire", "children", "shares", "humming", "ritual"]),
+        ("cave", ["cave", "stone", "echo", "dark"]),
+        ("meadow", ["berry", "berries", "grass", "meadow"]),
+    ]
+    for location_id, keywords in location_keywords:
+        if any(keyword in action for keyword in keywords):
+            return location_id
+    return "fire_pit"
+
+
+def _infer_resource_effect(action: str) -> tuple[str, str]:
+    if any(word in action for word in ["gather", "berries", "food", "shares"]):
+        return "food", "increase"
+    if any(word in action for word in ["fish", "fishing", "net"]):
+        return "fish", "increase"
+    if any(word in action for word in ["wood", "repairs", "craft"]):
+        return "wood", "decrease"
+    if any(word in action for word in ["stone", "cave"]):
+        return "stone", "increase"
+    if any(word in action for word in ["tells", "hidden name", "stars", "spiral", "omen"]):
+        return "lore", "increase"
+    return "lore", "increase"
+
+
+def _describe_world_event(agent_id: str, location_id: str, resource_id: str, effect: str, amount: int) -> str:
+    verb = "changed"
+    if effect == "increase":
+        verb = "increased"
+    elif effect == "decrease":
+        verb = "consumed"
+    return f"{agent_id} {verb} {resource_id} by {amount} at {location_id}."

--- a/frontend/src/components/SandboxWorld.tsx
+++ b/frontend/src/components/SandboxWorld.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { fetchJson } from '../lib/api';
-import type { AgentState, SandboxState } from '../types';
+import type { AgentState, SandboxState, WorldLocation } from '../types';
 
 export function SandboxWorld() {
     const [state, setState] = useState<SandboxState | null>(null);
@@ -36,6 +36,11 @@ export function SandboxWorld() {
                     backgroundColor: '#1a202c', // Dark modern map background
                 }}
             >
+                {/* Render World Locations */}
+                {state?.world?.locations.map(location => (
+                    <LocationMarker key={location.id} location={location} />
+                ))}
+
                 {/* Render Agents */}
                 {state && state.agents.map(agent => (
                     <AgentIcon key={agent.id} agent={agent} />
@@ -51,9 +56,71 @@ export function SandboxWorld() {
             <div className="absolute top-4 left-4 glass-panel px-4 py-2 flex gap-4 text-sm font-mono text-white/70">
                 <div>Turn: <span className="text-neonBlue">{state?.turn ?? 0}</span></div>
                 <div>Agents: <span className="text-neonBlue">{state?.agents.length ?? 0}</span></div>
+                <div>Weather: <span className="text-neonBlue">{state?.world?.weather ?? 'unknown'}</span></div>
             </div>
+
+            {state?.world && (
+                <div className="absolute top-16 left-4 glass-panel px-4 py-3 text-xs font-mono text-white/70 w-64">
+                    <div className="text-white/90 font-bold mb-2">World resources</div>
+                    <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                        {Object.entries(state.world.resources).map(([name, value]) => (
+                            <div key={name} className="flex justify-between gap-2">
+                                <span className="capitalize">{name}</span>
+                                <span className="text-neonBlue">{value}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
         </div>
     );
+}
+
+function LocationMarker({ location }: { location: WorldLocation }) {
+    const left = 20 + (location.x / 100) * 760;
+    const top = 20 + (location.y / 100) * 560;
+    const icon = biomeIcon(location.biome);
+
+    return (
+        <div
+            className="absolute flex flex-col items-center text-white/70"
+            style={{
+                left: `${left}px`,
+                top: `${top}px`,
+                transform: 'translate(-50%, -50%)'
+            }}
+            title={`${location.name} / ${location.resources.join(', ')} / activity ${location.activity}`}
+        >
+            <div className="text-2xl opacity-80 drop-shadow-[0_0_10px_rgba(255,255,255,0.25)]">
+                {icon}
+            </div>
+            <div className="mt-1 text-[10px] font-bold tracking-wide bg-black/50 px-2 py-0.5 rounded border border-white/10">
+                {location.name}
+            </div>
+            {location.activity > 0 && (
+                <div className="mt-1 text-[9px] text-neonBlue bg-black/60 px-1 rounded">
+                    activity {location.activity}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function biomeIcon(biome: string) {
+    switch (biome) {
+        case 'water':
+            return '🌊';
+        case 'forest':
+            return '🌲';
+        case 'settlement':
+            return '🔥';
+        case 'stone':
+            return '⛰️';
+        case 'grassland':
+            return '🌾';
+        default:
+            return '◇';
+    }
 }
 
 function AgentIcon({ agent }: { agent: AgentState }) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,11 +6,38 @@ export interface AgentState {
   emotion: string;
   action: string;
   speech: string;
+  location_id?: string | null;
+}
+
+export interface WorldLocation {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  biome: string;
+  resources: string[];
+  activity: number;
+  last_event: string;
+}
+
+export interface WorldState {
+  weather: string;
+  resources: Record<string, number>;
+  locations: WorldLocation[];
+  events: Array<{
+    agent_id: string;
+    location_id: string;
+    resource_id: string;
+    effect: string;
+    amount: number;
+    description: string;
+  }>;
 }
 
 export interface SandboxState {
   turn: number;
   agents: AgentState[];
+  world?: WorldState;
 }
 
 export interface UniverseParticleData {

--- a/tests/test_demo_simulation_cli.py
+++ b/tests/test_demo_simulation_cli.py
@@ -36,6 +36,11 @@ class DemoSimulationCliTest(unittest.TestCase):
         state = json.loads(state_file.read_text())
         self.assertEqual(state["turn"], 1)
         self.assertEqual(len(state["agents"]), 5)
+        self.assertIn("world", state)
+        self.assertIn("resources", state["world"])
+        self.assertIn("locations", state["world"])
+        self.assertGreaterEqual(len(state["world"]["locations"]), 4)
+        self.assertTrue(any(agent.get("location_id") for agent in state["agents"]))
 
     def test_demo_cli_reproduces_same_sandbox_state_for_same_seed(self):
         repo = Path(__file__).resolve().parents[1]

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -1,0 +1,52 @@
+import random
+import unittest
+
+from backend.world_state import WorldState, apply_agent_action_to_world
+
+
+class WorldStateTest(unittest.TestCase):
+    def test_default_world_contains_locations_and_resources(self):
+        world = WorldState.create_default(random.Random(3))
+
+        self.assertGreaterEqual(len(world.locations), 4)
+        self.assertIn("river", world.locations)
+        self.assertIn("forest", world.locations)
+        self.assertIn("food", world.resources)
+        self.assertIn("wood", world.resources)
+        self.assertIn("stone", world.resources)
+
+    def test_agent_action_updates_resource_and_location_deterministically(self):
+        rng = random.Random(7)
+        world = WorldState.create_default(rng)
+        before_food = world.resources["food"]
+        before_river_activity = world.locations["river"].activity
+
+        event = apply_agent_action_to_world(
+            world,
+            "demo-agent-0",
+            "Agent-0 [DEMO] gathers bright berries near the river and shares them by the fire.",
+            rng,
+        )
+
+        self.assertEqual(event["agent_id"], "demo-agent-0")
+        self.assertEqual(event["location_id"], "river")
+        self.assertEqual(event["resource_id"], "food")
+        self.assertEqual(event["effect"], "increase")
+        self.assertGreater(world.resources["food"], before_food)
+        self.assertEqual(world.locations["river"].activity, before_river_activity + 1)
+        self.assertEqual(world.locations["river"].last_event, event["description"])
+
+    def test_same_seed_and_actions_produce_same_world_state(self):
+        action = "Agent-0 [DEMO] repairs a fishing net while humming an old rhythm."
+
+        def run_once():
+            rng = random.Random(11)
+            world = WorldState.create_default(rng)
+            apply_agent_action_to_world(world, "demo-agent-0", action, rng)
+            return world.to_dict()
+
+        self.assertEqual(run_once(), run_once())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / なぜこの変更が必要か

Issue #4 の次ステップとして、現状の sandbox が「agent の短文ログと点の移動」に寄っている状態から、場所・資源・天候を持つ文明シミュレーションへ近づけます。

World State を導入することで、agent の行動が `river` / `forest` / `fire pit` / `cave` などの場所と、`food` / `wood` / `stone` / `fish` / `lore` などの資源に影響し、frontend でも「文明の状態が変化している」ことを観測できるようにします。

Closes #4

## What / 何を変更したか

- `backend/world_state.py` を追加
  - `WorldState`
  - `Location`
  - `apply_agent_action_to_world`
- default world に以下を追加
  - locations: river / forest / fire pit / cave / meadow
  - resources: food / wood / stone / fish / lore
  - weather
- simulation step で agent action から location/resource/effect を推定し、world state に反映
- `sandbox_state.json` に `world` と agent の `location_id` を出力
- agent の sandbox 座標を、action が影響した location 付近へ移動するように変更
- frontend sandbox map に location marker と resource panel を追加
- world state と demo CLI の unittest を追加・更新

## Verification / 検証

```bash
python3 -m unittest discover -s tests -v
python3 -m compileall -q backend dev_runner.py
python3 backend/simulation.py --demo --seed 42 --turns 2 --sleep 0
cd frontend && npm run lint
cd frontend && npm run build
```

すべて成功しました。

補足: frontend build は既存の Vite chunk size warning を出しますが、build 自体は成功しています。
