### PR TITLE
feat: agent needs and relationship loop

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -1,6 +1,8 @@
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from pydantic import BaseModel, Field
+import re
 import uuid
+
 
 class Needs(BaseModel):
     survival: float = 1.0     # 0.0 to 1.0
@@ -8,6 +10,7 @@ class Needs(BaseModel):
     belonging: float = 0.5
     esteem: float = 0.5
     self_actualization: float = 0.1
+
 
 class AgentState(BaseModel):
     boredom: float = 0.0      # Increases when doing repeated actions
@@ -20,25 +23,155 @@ class AgentState(BaseModel):
     current_action: str = "Idle" # Sandbox action text
     speech: str = ""          # Sandbox speech bubble
 
+
 class AgentIdentity(BaseModel):
     agent_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     personality: str          # e.g., "Curious and brave", "Cautious and traditional"
     skills: Dict[str, float] = Field(default_factory=dict) # e.g., {"farming": 0.2, "crafting": 0.1}
 
+
 class Agent:
     def __init__(self, name: str, personality: str):
         self.identity = AgentIdentity(name=name, personality=personality)
         self.state = AgentState()
         self.memory = None # Will be injected
+        self.brain: Optional[Any] = None
+        self.relationships: Dict[str, float] = {}
+        self.last_action: str = "Idle"
 
     def decide_next_action(self, context: str) -> str:
-        # Placeholder for LLM routing logic
-        # 1. Check boredom/curiosity
-        # 2. If bored > 0.8, try something crazy (High temperature LLM call)
-        # 3. If needs.survival < 0.3, focus on eating/gathering
-        pass
+        prompt = self._build_action_prompt(context)
+        if self.brain is not None and hasattr(self.brain, "chat_daily"):
+            result = self.brain.chat_daily(prompt)
+            if result and "[FALLBACK]" not in result:
+                return result
+
+        return self._heuristic_next_action(context)
 
     def update_state_after_action(self, action: str):
-        # Update boredom, energy, needs based on action outcome
-        pass
+        lowered = action.lower()
+        previous_action = self.last_action.lower()
+        repeated = any(token in lowered and token in previous_action for token in ["gather", "fish", "explore", "talk", "rest", "craft", "share", "repair"])
+
+        energy_delta = -0.05
+        boredom_delta = 0.02
+
+        if any(word in lowered for word in ["rest", "sleep", "recover", "nap"]):
+            energy_delta = 0.16
+            boredom_delta = -0.08
+            self.state.needs.safety = min(1.0, self.state.needs.safety + 0.04)
+        elif any(word in lowered for word in ["gather", "hunt", "fish", "eat", "food", "berries"]) and not any(word in lowered for word in ["share", "shares", "talk", "discuss", "help", "meet"]):
+            energy_delta = 0.06 if "eat" in lowered else -0.03
+            boredom_delta = -0.02
+            self.state.needs.survival = min(1.0, self.state.needs.survival + 0.08)
+        elif any(word in lowered for word in ["talk", "discuss", "share", "shares", "help", "meet"]):
+            energy_delta = -0.04
+            boredom_delta = -0.12
+            self.state.needs.belonging = min(1.0, self.state.needs.belonging + 0.12)
+            self.state.needs.esteem = min(1.0, self.state.needs.esteem + 0.03)
+        elif any(word in lowered for word in ["explore", "discover", "wander", "search", "travel"]):
+            energy_delta = -0.08
+            boredom_delta = -0.14
+            self.state.curiosity = min(1.0, self.state.curiosity + 0.06)
+        elif any(word in lowered for word in ["craft", "repair", "build", "make"]):
+            energy_delta = -0.07
+            boredom_delta = -0.04
+            self.state.needs.esteem = min(1.0, self.state.needs.esteem + 0.1)
+            self.state.needs.self_actualization = min(1.0, self.state.needs.self_actualization + 0.04)
+
+        if repeated:
+            boredom_delta += 0.08
+
+        self.state.energy = _clamp(self.state.energy + energy_delta)
+        self.state.boredom = _clamp(self.state.boredom + boredom_delta)
+        self.state.needs.survival = _clamp(self.state.needs.survival)
+        self.state.needs.safety = _clamp(self.state.needs.safety)
+        self.state.needs.belonging = _clamp(self.state.needs.belonging)
+        self.state.needs.esteem = _clamp(self.state.needs.esteem)
+        self.state.needs.self_actualization = _clamp(self.state.needs.self_actualization)
+
+        for other_agent_id, strength in list(self.relationships.items()):
+            if not re.search(rf"\b{re.escape(other_agent_id)}\b", action):
+                continue
+            if any(word in lowered for word in ["share", "shares", "talk", "help", "gift", "listen", "meet"]):
+                strength += 0.1
+            elif any(word in lowered for word in ["argue", "fight", "insult", "steal", "blame"]):
+                strength -= 0.15
+            else:
+                strength += 0.02
+            self.relationships[other_agent_id] = _clamp_relationship(strength)
+
+        self.state.current_action = action
+        self.last_action = action
+        return None
+
+    def _build_action_prompt(self, context: str) -> str:
+        relationship_lines = self._relationship_lines()
+        relationship_section = "\n".join(relationship_lines) if relationship_lines else "- none yet"
+        needs = self.state.needs
+        return (
+            f"You are {self.identity.name}, a {self.identity.personality}.\n"
+            f"Current context: {context}\n\n"
+            f"State:\n"
+            f"- energy: {self.state.energy:.2f}\n"
+            f"- boredom: {self.state.boredom:.2f}\n"
+            f"- curiosity: {self.state.curiosity:.2f}\n"
+            f"- needs: survival={needs.survival:.2f}, safety={needs.safety:.2f}, belonging={needs.belonging:.2f}, esteem={needs.esteem:.2f}, self_actualization={needs.self_actualization:.2f}\n\n"
+            f"Relationship context:\n{relationship_section}\n\n"
+            "Choose one short action (1-2 sentences) that fits the current state."
+        )
+
+    def _relationship_lines(self) -> list[str]:
+        lines = []
+        for other_agent_id, strength in sorted(self.relationships.items(), key=lambda item: item[1], reverse=True):
+            lines.append(f"- {other_agent_id}: trust {strength:+.2f}")
+        return lines
+
+    def _heuristic_next_action(self, context: str) -> str:
+        strongest_relationship = max(self.relationships.values(), default=0.0)
+        if self.state.needs.survival < 0.35:
+            if strongest_relationship > 0.4:
+                partner = self._best_relationship_target(prefer_positive=True)
+                if partner:
+                    return f"{self.identity.name} gathers food with {partner} near the river."
+            return f"{self.identity.name} gathers food near the river."
+
+        if self.state.boredom > 0.8 or self.state.curiosity > 0.85:
+            if strongest_relationship > 0.3:
+                partner = self._best_relationship_target(prefer_positive=True)
+                if partner:
+                    return f"{self.identity.name} explores a new path with {partner} beyond the meadow."
+            return f"{self.identity.name} explores the forest for something new."
+
+        if self.state.needs.belonging < 0.45 or strongest_relationship > 0.6:
+            partner = self._best_relationship_target(prefer_positive=True)
+            if partner:
+                return f"{self.identity.name} shares a story with {partner} by the fire."
+            return f"{self.identity.name} talks with neighbors by the fire."
+
+        if self.state.energy < 0.35:
+            return f"{self.identity.name} rests by the fire to recover energy."
+
+        if any(word in context.lower() for word in ["storm", "winter", "hunger", "empty"]):
+            return f"{self.identity.name} checks the stores and gathers food near the river."
+
+        return f"{self.identity.name} crafts a small tool and reflects on the day."
+
+    def _best_relationship_target(self, prefer_positive: bool = True) -> Optional[str]:
+        if not self.relationships:
+            return None
+        items = sorted(self.relationships.items(), key=lambda item: item[1], reverse=prefer_positive)
+        for agent_id, strength in items:
+            if prefer_positive and strength <= 0:
+                continue
+            return agent_id
+        return items[0][0] if items else None
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _clamp_relationship(value: float) -> float:
+    return max(-1.0, min(1.0, value))

--- a/backend/simulation.py
+++ b/backend/simulation.py
@@ -51,6 +51,15 @@ class Simulation:
             for i, agent in enumerate(self.agents):
                 agent.identity.agent_id = f"demo-agent-{i}"
 
+        # Seed simple relationship graph so social context can influence prompts and state.
+        for agent in self.agents:
+            agent.relationships = {
+                other.identity.agent_id: 0.0
+                for other in self.agents
+                if other.identity.agent_id != agent.identity.agent_id
+            }
+            agent.brain = self.router
+
         # Inject memory system into agents
         for a in self.agents:
             a.memory = memory_factory(agent_id=a.identity.agent_id)
@@ -159,7 +168,8 @@ class Simulation:
         self._generate_chronicle(self.turn)
 
     def _run_daily_action(self, agent: Agent) -> str | None:
-        action = self.router.chat_daily(f"What will {agent.identity.name} do?")
+        context = self._build_agent_context(agent)
+        action = agent.decide_next_action(context)
 
         if not action or "[FALLBACK]" in action:
             print(f"[WARN] Agent {agent.identity.name} got a fallback response at turn {self.turn}. Skipping save.")
@@ -173,6 +183,7 @@ class Simulation:
             self.random,
         )
         self.agent_locations[agent.identity.agent_id] = world_event["location_id"]
+        agent.update_state_after_action(action)
 
         # --- Sandbox State Update ---
         parsed = parse_agent_action(action)
@@ -184,6 +195,25 @@ class Simulation:
         agent.state.x = max(0.0, min(100.0, location.x + self.random.uniform(-5.0, 5.0)))
         agent.state.y = max(0.0, min(100.0, location.y + self.random.uniform(-5.0, 5.0)))
         return action
+
+    def _build_agent_context(self, agent: Agent) -> str:
+        location_id = self.agent_locations.get(agent.identity.agent_id)
+        if location_id and location_id in self.world.locations:
+            location = self.world.locations[location_id]
+            location_text = f"{location.name} ({location.biome}) at ({location.x:.1f}, {location.y:.1f})"
+        else:
+            location_text = "unknown location"
+
+        resource_bits = ", ".join(f"{name}={amount}" for name, amount in sorted(self.world.resources.items()))
+        relationship_bits = ", ".join(
+            f"{other}:{strength:+.2f}"
+            for other, strength in sorted(agent.relationships.items(), key=lambda item: item[1], reverse=True)
+        ) or "none"
+        recent_events = "; ".join(event["description"] for event in self.world.events[-3:]) or "none"
+        return (
+            f"Turn {self.turn}; weather={self.world.weather}; location={location_text}; "
+            f"resources={resource_bits}; recent_events={recent_events}; relationships={relationship_bits}"
+        )
 
     def _run_reflection(self, agent: Agent) -> str | None:
         summarized = agent.memory.reflect_and_summarize(current_time=self.turn)
@@ -214,6 +244,10 @@ class Simulation:
                 "action": agent.state.current_action,
                 "speech": agent.state.speech,
                 "location_id": self.agent_locations.get(agent.identity.agent_id),
+                "relationships": {
+                    other_id: strength
+                    for other_id, strength in sorted(agent.relationships.items())
+                },
             })
 
         static_dir = os.path.join(os.path.dirname(__file__), "static")

--- a/tests/test_agent_state_loop.py
+++ b/tests/test_agent_state_loop.py
@@ -1,0 +1,97 @@
+import unittest
+
+from backend.agent import Agent
+
+
+class CapturingBrain:
+    def __init__(self, response: str = "Agent-0 gathers food by the river."):
+        self.response = response
+        self.prompts = []
+
+    def chat_daily(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.response
+
+
+class AgentStateLoopTest(unittest.TestCase):
+    def test_decide_next_action_prefers_food_when_survival_is_low(self):
+        agent = Agent("Agent-0", "Practical and cautious")
+        agent.state.needs.survival = 0.2
+        agent.state.boredom = 0.1
+        agent.state.energy = 0.8
+
+        action = agent.decide_next_action("Winter is coming and the pantry is nearly empty.")
+
+        self.assertIsInstance(action, str)
+        self.assertTrue(
+            any(keyword in action.lower() for keyword in ["food", "gather", "hunt", "fish", "eat"]),
+            msg=action,
+        )
+
+    def test_decide_next_action_prefers_exploration_when_boredom_is_high(self):
+        agent = Agent("Agent-1", "Restless and curious")
+        agent.state.needs.survival = 0.9
+        agent.state.boredom = 0.95
+        agent.state.curiosity = 0.9
+        agent.state.energy = 0.7
+
+        action = agent.decide_next_action("The settlement feels safe but uneventful.")
+
+        self.assertIsInstance(action, str)
+        self.assertTrue(
+            any(keyword in action.lower() for keyword in ["explore", "discover", "wander", "search", "forest"]),
+            msg=action,
+        )
+
+    def test_decide_next_action_includes_state_and_relationship_context_in_prompt(self):
+        agent = Agent("Agent-2", "Thoughtful and social")
+        brain = CapturingBrain()
+        agent.brain = brain
+        agent.state.needs.survival = 0.65
+        agent.state.needs.belonging = 0.3
+        agent.state.boredom = 0.4
+        agent.state.curiosity = 0.8
+        agent.relationships = {"ally-1": 0.85, "rival-9": -0.4}
+
+        result = agent.decide_next_action("A council is meeting near the fire pit.")
+
+        self.assertEqual(result, brain.response)
+        self.assertEqual(len(brain.prompts), 1)
+        prompt = brain.prompts[0]
+        self.assertIn("Agent-2", prompt)
+        self.assertIn("survival", prompt)
+        self.assertIn("boredom", prompt)
+        self.assertIn("curiosity", prompt)
+        self.assertIn("ally-1", prompt)
+        self.assertIn("rival-9", prompt)
+        self.assertIn("relationship", prompt.lower())
+
+    def test_update_state_after_action_reduces_energy_and_increases_belonging_for_social_actions(self):
+        agent = Agent("Agent-3", "Helpful and warm")
+        agent.state.energy = 0.8
+        agent.state.boredom = 0.6
+        agent.state.needs.belonging = 0.4
+        agent.relationships = {"Agent-4": 0.0}
+
+        agent.update_state_after_action("Agent-3 shares food with Agent-4 by the fire.")
+
+        self.assertLess(agent.state.energy, 0.8)
+        self.assertLess(agent.state.boredom, 0.6)
+        self.assertGreater(agent.state.needs.belonging, 0.4)
+        self.assertGreater(agent.relationships["Agent-4"], 0.0)
+
+    def test_update_state_after_action_raises_survival_for_food_gathering_and_caps_values(self):
+        agent = Agent("Agent-5", "Steady and practical")
+        agent.state.energy = 0.98
+        agent.state.boredom = 0.05
+        agent.state.needs.survival = 0.95
+
+        agent.update_state_after_action("Agent-5 gathers berries and eats a full meal after fishing.")
+
+        self.assertGreater(agent.state.needs.survival, 0.95)
+        self.assertLessEqual(agent.state.energy, 1.0)
+        self.assertGreaterEqual(agent.state.boredom, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / なぜこの変更が必要か
Agent の `needs` や `AgentState` は存在していたものの、行動選択と状態更新が placeholder のままでした。
そのため、空腹・疲労・好奇心・関係性がシミュレーションに反映されず、文明の“生活感”が弱い状態でした。

## What / 何を変更したか
- `Agent.decide_next_action` を実装し、state/needs/relationships を含むプロンプトを生成
- `Agent.update_state_after_action` を実装し、行動に応じて energy / boredom / needs / relationships を更新
- survival が低いと食料行動、boredom / curiosity が高いと探索行動を選びやすくするヒューリスティックを追加
- `Simulation` 側で agent の関係グラフを初期化し、daily action に state context を渡すよう変更
- sandbox 状態に relationships を含めて、行動と関係性の変化を観測できるようにした
- 追加テストで、低 survival / 高 boredom / prompt context / state update / relationship 更新を検証

Closes #5

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q backend tests`
