### PR TITLE
feat: myth feedback loop

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -130,6 +130,18 @@ class Agent:
 
     def _heuristic_next_action(self, context: str) -> str:
         strongest_relationship = max(self.relationships.values(), default=0.0)
+        lowered_context = context.lower()
+
+        if any(word in lowered_context for word in ["taboo", "forbidden", "avoid fishing", "river taboo"]) and any(
+            word in lowered_context for word in ["fish", "fishing", "river", "dawn"]
+        ):
+            if self.state.needs.survival < 0.35:
+                partner = self._best_relationship_target(prefer_positive=True)
+                if partner:
+                    return f"{self.identity.name} gathers berries in the meadow with {partner}, honoring the taboo."
+                return f"{self.identity.name} gathers berries in the meadow, honoring the taboo."
+            return f"{self.identity.name} gathers berries in the meadow instead of fishing at dawn."
+
         if self.state.needs.survival < 0.35:
             if strongest_relationship > 0.4:
                 partner = self._best_relationship_target(prefer_positive=True)
@@ -153,8 +165,11 @@ class Agent:
         if self.state.energy < 0.35:
             return f"{self.identity.name} rests by the fire to recover energy."
 
-        if any(word in context.lower() for word in ["storm", "winter", "hunger", "empty"]):
+        if any(word in lowered_context for word in ["storm", "winter", "hunger", "empty"]):
             return f"{self.identity.name} checks the stores and gathers food near the river."
+
+        if any(word in lowered_context for word in ["prophecy", "omen", "sacred_location"]):
+            return f"{self.identity.name} visits the fire pit to listen for the meaning of the omen."
 
         return f"{self.identity.name} crafts a small tool and reflects on the day."
 

--- a/backend/simulation.py
+++ b/backend/simulation.py
@@ -10,7 +10,7 @@ from typing import Optional
 from agent import Agent
 from demo_runtime import DemoLLMRouter, DemoMemorySystem
 from sandbox_utils import parse_agent_action
-from world_state import WorldState, apply_agent_action_to_world
+from world_state import WorldState, apply_agent_action_to_world, derive_beliefs_from_reflection
 
 
 class Simulation:
@@ -210,9 +210,14 @@ class Simulation:
             for other, strength in sorted(agent.relationships.items(), key=lambda item: item[1], reverse=True)
         ) or "none"
         recent_events = "; ".join(event["description"] for event in self.world.events[-3:]) or "none"
+        belief_bits = "; ".join(
+            f"{belief.kind}={belief.text}"
+            for belief in self.world.beliefs[-3:]
+        ) or "none"
         return (
             f"Turn {self.turn}; weather={self.world.weather}; location={location_text}; "
-            f"resources={resource_bits}; recent_events={recent_events}; relationships={relationship_bits}"
+            f"resources={resource_bits}; recent_events={recent_events}; relationships={relationship_bits}; "
+            f"active beliefs={belief_bits}"
         )
 
     def _run_reflection(self, agent: Agent) -> str | None:
@@ -225,6 +230,8 @@ class Simulation:
 
         # Save embedding vector to ChromaDB memory in real mode; demo memory ignores this as short-term lore.
         self.router.extract_vector(exaggerated_memory)
+        beliefs = derive_beliefs_from_reflection(agent.identity.agent_id, exaggerated_memory, self.turn, self.random)
+        self.world.add_beliefs(beliefs)
         agent.memory.add_memory(
             f"[LEGEND] {exaggerated_memory}",
             importance=0.9,

--- a/backend/world_state.py
+++ b/backend/world_state.py
@@ -32,12 +32,35 @@ class Location:
 
 
 @dataclass
+class Belief:
+    """A myth-derived belief that can steer future agent behavior."""
+
+    kind: str
+    text: str
+    source_agent_id: str
+    source_turn: int
+    strength: float = 0.5
+    trigger: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "text": self.text,
+            "source_agent_id": self.source_agent_id,
+            "source_turn": self.source_turn,
+            "strength": self.strength,
+            "trigger": self.trigger,
+        }
+
+
+@dataclass
 class WorldState:
     """Mutable world state that makes agent actions affect civilization context."""
 
     weather: str
     resources: dict[str, int]
     locations: dict[str, Location] = field(default_factory=dict)
+    beliefs: list[Belief] = field(default_factory=list)
     events: list[dict[str, Any]] = field(default_factory=list)
 
     @classmethod
@@ -67,8 +90,15 @@ class WorldState:
             "weather": self.weather,
             "resources": dict(self.resources),
             "locations": [location.to_dict() for location in self.locations.values()],
+            "beliefs": [belief.to_dict() for belief in self.beliefs[-25:]],
             "events": list(self.events[-25:]),
         }
+
+    def add_beliefs(self, beliefs: list[Belief]) -> None:
+        if not beliefs:
+            return
+        self.beliefs.extend(beliefs)
+        self.beliefs = self.beliefs[-50:]
 
 
 def apply_agent_action_to_world(
@@ -106,6 +136,88 @@ def apply_agent_action_to_world(
     location.last_event = event["description"]
     world.events.append(event)
     return event
+
+
+def derive_beliefs_from_reflection(
+    agent_id: str,
+    reflection: str,
+    turn: int,
+    rng: random.Random | None = None,
+) -> list[Belief]:
+    """Convert a mythic reflection into one or more belief candidates."""
+
+    rng = rng or random.Random()
+    lowered = reflection.lower()
+    beliefs: list[Belief] = []
+
+    def add_belief(kind: str, text: str, trigger: str, base_strength: float = 0.6) -> None:
+        strength = min(1.0, base_strength + rng.uniform(0.0, 0.2))
+        beliefs.append(
+            Belief(
+                kind=kind,
+                text=text,
+                source_agent_id=agent_id,
+                source_turn=turn,
+                strength=strength,
+                trigger=trigger,
+            )
+        )
+
+    if any(word in lowered for word in ["punished", "forbidden", "avoid", "curse", "never"]):
+        if any(word in lowered for word in ["fish", "fishing", "river", "dawn"]):
+            add_belief(
+                "taboo",
+                "Avoid fishing at dawn near the river.",
+                "punishment around fishing at dawn",
+            )
+
+    if any(word in lowered for word in ["ritual", "chant", "humming", "dance", "offer"]):
+        add_belief(
+            "ritual",
+            "The village should repeat the chant or ritual that kept the spirits calm.",
+            "ritual language in the reflection",
+        )
+
+    if any(word in lowered for word in ["sacred", "holy", "spirit", "shrine"]):
+        if any(word in lowered for word in ["river", "forest", "cave", "meadow", "fire"]):
+            add_belief(
+                "sacred_location",
+                "A nearby place has become sacred and should be treated with care.",
+                "sacred place language in the reflection",
+            )
+
+    if any(word in lowered for word in ["omen", "sign", "stars", "spiral", "moon"]):
+        add_belief(
+            "omen",
+            "Signs in the sky warn the village to change its path.",
+            "omen language in the reflection",
+            base_strength=0.55,
+        )
+
+    if any(word in lowered for word in ["law", "rule", "must", "should", "custom"]):
+        add_belief(
+            "law",
+            "The village has learned a rule worth following.",
+            "law language in the reflection",
+        )
+
+    if any(word in lowered for word in ["will", "future", "one day", "spring", "return"]):
+        add_belief(
+            "prophecy",
+            "The reflection points to a future event the village should prepare for.",
+            "prophetic language in the reflection",
+            base_strength=0.52,
+        )
+
+    if not beliefs and reflection.strip():
+        add_belief(
+            "omen",
+            "The reflection feels like a sign worth remembering.",
+            "fallback myth recognition",
+            base_strength=0.4,
+        )
+
+    return beliefs
 
 
 def _infer_location_id(action: str) -> str:

--- a/frontend/src/components/SandboxWorld.tsx
+++ b/frontend/src/components/SandboxWorld.tsx
@@ -72,6 +72,26 @@ export function SandboxWorld() {
                     </div>
                 </div>
             )}
+
+            {state?.world?.beliefs?.length ? (
+                <div className="absolute top-16 right-4 glass-panel px-4 py-3 text-xs font-mono text-white/70 w-72 max-h-[260px] overflow-auto">
+                    <div className="text-white/90 font-bold mb-2">Active beliefs</div>
+                    <div className="space-y-2">
+                        {state.world.beliefs.slice(-6).reverse().map((belief, index) => (
+                            <div key={`${belief.kind}-${belief.source_agent_id}-${belief.source_turn}-${index}`} className="border border-white/10 rounded bg-black/30 p-2">
+                                <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-wide text-neonBlue">
+                                    <span>{belief.kind.replace('_', ' ')}</span>
+                                    <span>turn {belief.source_turn}</span>
+                                </div>
+                                <div className="mt-1 text-white/85 leading-snug">{belief.text}</div>
+                                <div className="mt-1 text-[10px] text-white/45">
+                                    from {belief.source_agent_id} · strength {belief.strength.toFixed(2)}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,10 +20,20 @@ export interface WorldLocation {
   last_event: string;
 }
 
+export interface WorldBelief {
+  kind: string;
+  text: string;
+  source_agent_id: string;
+  source_turn: number;
+  strength: number;
+  trigger: string;
+}
+
 export interface WorldState {
   weather: string;
   resources: Record<string, number>;
   locations: WorldLocation[];
+  beliefs: WorldBelief[];
   events: Array<{
     agent_id: string;
     location_id: string;

--- a/tests/test_myth_feedback_loop.py
+++ b/tests/test_myth_feedback_loop.py
@@ -1,0 +1,90 @@
+import json
+import random
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from backend.agent import Agent
+from backend.world_state import WorldState, derive_beliefs_from_reflection
+
+
+class MythFeedbackLoopTest(unittest.TestCase):
+    def test_derive_beliefs_from_reflection_creates_taboo_from_myth(self):
+        beliefs = derive_beliefs_from_reflection(
+            agent_id="demo-agent-0",
+            reflection="The river spirit punished those who fished at dawn, so the village learned to avoid the river before sunrise.",
+            turn=7,
+            rng=random.Random(3),
+        )
+
+        self.assertGreaterEqual(len(beliefs), 1)
+        kinds = {belief.kind for belief in beliefs}
+        self.assertIn("taboo", kinds)
+        self.assertTrue(any("avoid" in belief.text.lower() for belief in beliefs), beliefs)
+
+    def test_agent_decision_context_respects_active_belief_taboo(self):
+        agent = Agent("Agent-0", "Practical and cautious")
+        agent.state.needs.survival = 0.2
+        agent.state.energy = 0.8
+
+        action = agent.decide_next_action(
+            "Turn 7; weather=misty; active beliefs: taboo=avoid fishing at dawn near the river; "
+            "prophecy=the meadow will feed the village."
+        )
+
+        lowered = action.lower()
+        self.assertTrue(
+            any(keyword in lowered for keyword in ["meadow", "forest", "gather", "forage", "berries"]),
+            msg=action,
+        )
+        self.assertFalse("fish" in lowered and "river" in lowered, msg=action)
+
+    def test_world_state_serializes_active_beliefs(self):
+        world = WorldState.create_default(random.Random(9))
+        beliefs = derive_beliefs_from_reflection(
+            agent_id="demo-agent-1",
+            reflection="The hidden name of the cave became a sacred law, and the stars promised a return in spring.",
+            turn=11,
+            rng=random.Random(11),
+        )
+        world.add_beliefs(beliefs)
+
+        data = world.to_dict()
+        self.assertIn("beliefs", data)
+        self.assertGreaterEqual(len(data["beliefs"]), 1)
+        self.assertTrue(any(belief["kind"] in {"law", "prophecy", "sacred_location", "omen"} for belief in data["beliefs"]))
+
+    def test_simulation_context_includes_active_beliefs(self):
+        repo = Path(__file__).resolve().parents[1]
+        state_file = repo / "backend" / "static" / "sandbox_state.json"
+        if state_file.exists():
+            state_file.unlink()
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(repo / "backend" / "simulation.py"),
+                "--demo",
+                "--seed",
+                "5",
+                "--turns",
+                "6",
+                "--sleep",
+                "0",
+            ],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            timeout=20,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        state = json.loads(state_file.read_text())
+        self.assertIn("beliefs", state["world"])
+        self.assertGreaterEqual(len(state["world"]["beliefs"]), 1)
+        self.assertTrue(any(belief["kind"] in {"taboo", "omen", "law", "prophecy", "ritual", "sacred_location"} for belief in state["world"]["beliefs"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / なぜこの変更が必要か
神話や反芻された出来事が、次の turn の行動に反映されないままだと、Entropy Civil は「面白いログ」を出すだけで、文明の振る舞いを変える feedback loop になりません。
この変更で、reflection から belief を生成し、agent の行動選択と UI/API にまでつなげます。

## What / 何を変更したか
- `backend/world_state.py`
  - `Belief` を追加
  - reflection から `taboo / ritual / sacred_location / omen / law / prophecy` を導く `derive_beliefs_from_reflection` を追加
  - `WorldState` に beliefs を保持・シリアライズする機能を追加
- `backend/simulation.py`
  - reflection 生成後に belief を world state へ登録
  - agent prompt context に active beliefs を含めるよう変更
- `backend/agent.py`
  - beliefs の taboo を踏まえて、危険な行動を避けるヒューリスティックを追加
- `frontend`
  - sandbox state の型に beliefs を追加
  - Sandbox UI に active beliefs panel を追加
- tests
  - myth feedback loop の抽出・保存・行動への反映を検証するテストを追加

Closes #6

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q backend tests`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
