### PR TITLE
feat: structured event schema

### DIFF
--- a/backend/event_schema.py
+++ b/backend/event_schema.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, Optional
+
+
+def build_structured_event_data(
+    *,
+    event_type: str,
+    agent_id: str,
+    content: str,
+    turn: int,
+    location_id: Optional[str] = None,
+    target: Optional[str] = None,
+    cause: Optional[str] = None,
+    effect: Optional[str] = None,
+    world_event: Optional[Dict[str, Any]] = None,
+    importance: float = 0.5,
+    entropy_level: float = 0.0,
+    causal_parent_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create a JSON-serializable structured event payload."""
+
+    world_event = world_event or {}
+    action = _infer_action(event_type, content, world_event)
+    inferred_target = target or _infer_target(content)
+    inferred_location = location_id or world_event.get("location_id") or _infer_location(content, world_event)
+    inferred_cause = cause or _infer_cause(event_type, content, world_event)
+    inferred_effect = effect or _infer_effect(event_type, content, world_event)
+    tags = _build_tags(event_type, action, inferred_location, world_event, content)
+    return {
+        "actor": agent_id,
+        "action": action,
+        "target": inferred_target,
+        "location": inferred_location,
+        "cause": inferred_cause,
+        "effect": inferred_effect,
+        "outcome": _infer_outcome(event_type, content, world_event),
+        "tags": tags,
+        "importance": importance,
+        "entropy_level": entropy_level,
+        "causal_parent_id": causal_parent_id,
+        "turn": turn,
+        "event_type": event_type,
+        "content": content,
+    }
+
+
+def simulation_event_to_dict(event_row: Any) -> Dict[str, Any]:
+    """Flatten a SimulationEvent row/dict for API responses."""
+
+    if isinstance(event_row, dict):
+        base = dict(event_row)
+    else:
+        base = {
+            "id": getattr(event_row, "id", None),
+            "turn": getattr(event_row, "turn", None),
+            "agent_id": getattr(event_row, "agent_id", None),
+            "event_type": getattr(event_row, "event_type", None),
+            "content": getattr(event_row, "content", None),
+            "structured_data": getattr(event_row, "structured_data", None),
+            "created_at": getattr(event_row, "created_at", None),
+        }
+
+    structured = base.get("structured_data") or {}
+    payload = {
+        "id": base.get("id"),
+        "turn": base.get("turn"),
+        "agent_id": base.get("agent_id"),
+        "type": base.get("event_type"),
+        "content": base.get("content"),
+        "structured": structured,
+    }
+
+    payload.update(
+        {
+            "actor": structured.get("actor"),
+            "action": structured.get("action"),
+            "target": structured.get("target"),
+            "location": structured.get("location"),
+            "cause": structured.get("cause"),
+            "effect": structured.get("effect"),
+            "tags": structured.get("tags", []),
+            "importance": structured.get("importance"),
+            "entropy_level": structured.get("entropy_level"),
+            "causal_parent_id": structured.get("causal_parent_id"),
+        }
+    )
+    return payload
+
+
+def _infer_action(event_type: str, content: str, world_event: Dict[str, Any]) -> str:
+    lowered = content.lower()
+    if event_type == "REFLECTION":
+        return "reflect"
+    if "shares" in lowered or "share" in lowered:
+        return "share"
+    if any(word in lowered for word in ["gather", "gathers", "hunt", "fish", "forage"]):
+        return "gather"
+    if any(word in lowered for word in ["explore", "explores", "wander", "travel", "discover"]):
+        return "explore"
+    if any(word in lowered for word in ["rest", "sleep", "recover", "nap"]):
+        return "rest"
+    if any(word in lowered for word in ["craft", "repair", "build", "make"]):
+        return "craft"
+    if any(word in lowered for word in ["talk", "discuss", "meet", "listen", "help"]):
+        return "socialize"
+    if world_event.get("resource_id"):
+        return str(world_event["resource_id"])
+    return "act"
+
+
+def _infer_target(content: str) -> Optional[str]:
+    matches = re.findall(r"\b[A-Z][A-Za-z0-9_-]*-\d+\b", content)
+    return matches[0] if matches else None
+
+
+def _infer_location(content: str, world_event: Dict[str, Any]) -> Optional[str]:
+    lowered = content.lower()
+    if world_event.get("location_id"):
+        return str(world_event["location_id"])
+    for location_id, keywords in (
+        ("river", ["river", "fish", "fishing", "water"]),
+        ("forest", ["forest", "wood", "tree", "deer"]),
+        ("fire_pit", ["fire", "council", "story", "share", "ritual"]),
+        ("cave", ["cave", "stone", "echo", "dark"]),
+        ("meadow", ["meadow", "berry", "berries", "grass"]),
+    ):
+        if any(keyword in lowered for keyword in keywords):
+            return location_id
+    return None
+
+
+def _infer_cause(event_type: str, content: str, world_event: Dict[str, Any]) -> str:
+    if event_type == "REFLECTION":
+        return "memory consolidation"
+    resource_id = world_event.get("resource_id")
+    if resource_id:
+        return f"resource {resource_id} activity"
+    return "agent decision"
+
+
+def _infer_effect(event_type: str, content: str, world_event: Dict[str, Any]) -> str:
+    if event_type == "REFLECTION":
+        return "myth or belief update"
+    effect = world_event.get("effect")
+    if effect:
+        return str(effect)
+    return "changed"
+
+
+def _infer_outcome(event_type: str, content: str, world_event: Dict[str, Any]) -> str:
+    if event_type == "REFLECTION":
+        return "mythic memory synthesized"
+    resource_id = world_event.get("resource_id")
+    amount = world_event.get("amount")
+    effect = world_event.get("effect")
+    if resource_id and amount is not None and effect:
+        sign = "+" if effect == "increase" else "-"
+        return f"{resource_id} {sign}{amount}"
+    return "state changed"
+
+
+def _build_tags(
+    event_type: str,
+    action: str,
+    location_id: Optional[str],
+    world_event: Dict[str, Any],
+    content: str,
+) -> list[str]:
+    tags = {event_type.lower(), action}
+    if location_id:
+        tags.add(f"location:{location_id}")
+    resource_id = world_event.get("resource_id")
+    if resource_id:
+        tags.add(f"resource:{resource_id}")
+    lowered = content.lower()
+    for keyword, tag in (
+        ("taboo", "myth:taboo"),
+        ("ritual", "myth:ritual"),
+        ("spirit", "myth:spirit"),
+        ("omen", "myth:omen"),
+        ("prophecy", "myth:prophecy"),
+        ("law", "myth:law"),
+        ("council", "social:council"),
+        ("share", "social:share"),
+    ):
+        if keyword in lowered:
+            tags.add(tag)
+            if tag.startswith("myth:"):
+                tags.add("myth")
+    return sorted(tags)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,10 @@ from sqlalchemy.orm import Session
 import chromadb
 
 from database import get_db, engine, Base
+try:
+    from backend.event_schema import simulation_event_to_dict
+except ImportError:  # pragma: no cover - script execution fallback
+    from event_schema import simulation_event_to_dict
 import models
 
 # Create tables if they don't exist
@@ -93,7 +97,7 @@ def get_historical_logs(limit: int = 50, db: Session = Depends(get_db)):
     """Return stream of recent simulation events"""
     logs = db.query(models.SimulationEvent).order_by(models.SimulationEvent.id.desc()).limit(limit).all()
     # Return in reverse so oldest is first in the output
-    return {"logs": [{"id": l.id, "turn": l.turn, "type": l.event_type, "content": l.content} for l in reversed(logs)]}
+    return {"logs": [simulation_event_to_dict(l) for l in reversed(logs)]}
 
 @app.get("/api/epochs")
 def get_historical_epochs(db: Session = Depends(get_db)):

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,6 +3,12 @@ from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from database import Base
 
+try:
+    from backend.event_schema import simulation_event_to_dict
+except ImportError:  # pragma: no cover - script execution fallback
+    from event_schema import simulation_event_to_dict
+
+
 class SimulationEvent(Base):
     __tablename__ = "simulation_events"
 
@@ -11,8 +17,13 @@ class SimulationEvent(Base):
     agent_id = Column(String, index=True)
     event_type = Column(String)  # e.g., "LOCAL_CHAT", "CLOUD_SUMMARY", "ENTROPY"
     content = Column(Text)
+    structured_data = Column(JSON, nullable=True)
     vector_hash = Column(String, nullable=True) # Link to ChromaDB if stored
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    def to_dict(self):
+        return simulation_event_to_dict(self)
+
 
 class HistoricalEpoch(Base):
     __tablename__ = "historical_epochs"
@@ -27,6 +38,7 @@ class HistoricalEpoch(Base):
     
     # Relationship to manually curated art
     artworks = relationship("CuratedArtwork", back_populates="epoch")
+
 
 class CuratedArtwork(Base):
     __tablename__ = "curated_artworks"

--- a/backend/simulation.py
+++ b/backend/simulation.py
@@ -11,6 +11,10 @@ from agent import Agent
 from demo_runtime import DemoLLMRouter, DemoMemorySystem
 from sandbox_utils import parse_agent_action
 from world_state import WorldState, apply_agent_action_to_world, derive_beliefs_from_reflection
+try:
+    from backend.event_schema import build_structured_event_data
+except ImportError:  # pragma: no cover - script execution fallback
+    from event_schema import build_structured_event_data
 
 
 class Simulation:
@@ -125,19 +129,33 @@ class Simulation:
 
     def _step_with_db(self):
         db = self._SessionLocal()
+        daily_event_ids: dict[str, int] = {}
         try:
             for agent in self.agents:
                 action = self._run_daily_action(agent)
                 if not action:
                     continue
 
+                world_event = self.world.events[-1] if self.world.events else {}
+                structured_data = build_structured_event_data(
+                    event_type="DAILY_ACTION",
+                    agent_id=agent.identity.agent_id,
+                    content=action,
+                    turn=self.turn,
+                    location_id=world_event.get("location_id"),
+                    world_event=world_event,
+                    importance=0.5,
+                )
                 event = self._models.SimulationEvent(
                     turn=self.turn,
                     agent_id=agent.identity.agent_id,
                     event_type="DAILY_ACTION",
                     content=action,
+                    structured_data=structured_data,
                 )
                 db.add(event)
+                db.flush()
+                daily_event_ids[agent.identity.agent_id] = event.id
 
             if self.turn % 5 == 0 and self.turn > 0:
                 print(">>> The agents are reflecting... (Entropy Injection)")
@@ -146,11 +164,21 @@ class Simulation:
                     if not reflection:
                         continue
 
+                    structured_data = build_structured_event_data(
+                        event_type="REFLECTION",
+                        agent_id=agent.identity.agent_id,
+                        content=reflection,
+                        turn=self.turn,
+                        causal_parent_id=daily_event_ids.get(agent.identity.agent_id),
+                        entropy_level=0.3,
+                        importance=0.9,
+                    )
                     event = self._models.SimulationEvent(
                         turn=self.turn,
                         agent_id=agent.identity.agent_id,
                         event_type="REFLECTION",
                         content=reflection,
+                        structured_data=structured_data,
                     )
                     db.add(event)
 

--- a/frontend/src/components/CodeOfHistory.tsx
+++ b/frontend/src/components/CodeOfHistory.tsx
@@ -73,22 +73,63 @@ export function CodeOfHistory() {
             <div className="flex-1 pl-8 flex flex-col justify-end overflow-hidden pb-8 relative">
                 <div className="absolute inset-x-0 top-0 h-24 pointer-events-none bg-gradient-to-b from-black to-transparent z-10" />
                 <div className="flex flex-col gap-2 relative z-0">
-                    {logs.map((log, idx) => (
-                        <motion.div
-                            initial={{ opacity: 0, x: -10 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            key={log.id || idx}
-                            className={`text-sm ${log.content?.includes('[エントロピー注入]') || log.type === 'REFLECTION' ? 'text-neonPurple font-bold' :
-                                log.type === 'CLOUD_SUMMARY' ? 'text-neonBlue' :
-                                    log.content?.includes('-->') ? 'text-matrixGreen/70' :
-                                        'text-white/60'
-                                }`}
-                        >
-                            <span className="opacity-40 mr-4">T-{log.turn}</span>
-                            <span className="opacity-40 mr-4 text-xs">[{log.type}]</span>
-                            {log.content}
-                        </motion.div>
-                    ))}
+                    {logs.map((log, idx) => {
+                        const structured = log.structured ?? {
+                            actor: log.actor,
+                            action: log.action,
+                            target: log.target,
+                            location: log.location,
+                            cause: log.cause,
+                            effect: log.effect,
+                            tags: log.tags,
+                            importance: log.importance,
+                            entropy_level: log.entropy_level,
+                            causal_parent_id: log.causal_parent_id,
+                        };
+                        const summaryBits = [
+                            structured.actor && `actor:${structured.actor}`,
+                            structured.action && `action:${structured.action}`,
+                            structured.location && `location:${structured.location}`,
+                            structured.target && `target:${structured.target}`,
+                            structured.causal_parent_id != null && `parent:#${structured.causal_parent_id}`,
+                        ].filter(Boolean) as string[];
+                        const tagBits = structured.tags?.length
+                            ? structured.tags.map((tag) => `#${tag}`)
+                            : [];
+
+                        return (
+                            <motion.div
+                                initial={{ opacity: 0, x: -10 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                key={log.id || idx}
+                                className={`text-sm ${log.content?.includes('[エントロピー注入]') || log.type === 'REFLECTION' ? 'text-neonPurple font-bold' :
+                                    log.type === 'CLOUD_SUMMARY' ? 'text-neonBlue' :
+                                        log.content?.includes('-->') ? 'text-matrixGreen/70' :
+                                            'text-white/60'
+                                    }`}
+                            >
+                                <div>
+                                    <span className="opacity-40 mr-4">T-{log.turn}</span>
+                                    <span className="opacity-40 mr-4 text-xs">[{log.type}]</span>
+                                    {log.content}
+                                </div>
+                                {(summaryBits.length > 0 || tagBits.length > 0) && (
+                                    <div className="mt-1 flex flex-wrap gap-2 text-[11px] text-white/35">
+                                        {summaryBits.map((bit) => (
+                                            <span key={bit} className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5">
+                                                {bit}
+                                            </span>
+                                        ))}
+                                        {tagBits.map((bit) => (
+                                            <span key={bit} className="rounded-full border border-neonBlue/20 bg-neonBlue/10 px-2 py-0.5 text-neonBlue/80">
+                                                {bit}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                            </motion.div>
+                        );
+                    })}
                     {logs.length === 0 && (
                         <div className="text-white/20 italic">シミュレーションログ待機中... (Waiting for logs...)</div>
                     )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -64,11 +64,35 @@ export interface UniverseResponse {
   error?: string;
 }
 
+export interface StructuredHistoryData {
+  actor?: string | null;
+  action?: string | null;
+  target?: string | null;
+  location?: string | null;
+  cause?: string | null;
+  effect?: string | null;
+  tags?: string[];
+  importance?: number | null;
+  entropy_level?: number | null;
+  causal_parent_id?: number | null;
+}
+
 export interface HistoryLog {
   id: number;
   turn: number;
   type: string;
   content: string;
+  structured?: StructuredHistoryData;
+  actor?: string | null;
+  action?: string | null;
+  target?: string | null;
+  location?: string | null;
+  cause?: string | null;
+  effect?: string | null;
+  tags?: string[];
+  importance?: number | null;
+  entropy_level?: number | null;
+  causal_parent_id?: number | null;
 }
 
 export interface HistoryResponse {

--- a/tests/test_structured_events.py
+++ b/tests/test_structured_events.py
@@ -1,0 +1,81 @@
+import unittest
+
+from backend.event_schema import build_structured_event_data, simulation_event_to_dict
+
+
+class StructuredEventsTest(unittest.TestCase):
+    def test_build_structured_event_data_for_daily_action_contains_core_fields(self):
+        structured = build_structured_event_data(
+            event_type="DAILY_ACTION",
+            agent_id="demo-agent-0",
+            content="Agent-0 gathers food near the river with Agent-1.",
+            turn=12,
+            location_id="river",
+            world_event={
+                "location_id": "river",
+                "resource_id": "food",
+                "effect": "increase",
+                "amount": 2,
+            },
+        )
+
+        self.assertEqual(structured["actor"], "demo-agent-0")
+        self.assertEqual(structured["action"], "gather")
+        self.assertEqual(structured["location"], "river")
+        self.assertEqual(structured["effect"], "increase")
+        self.assertIn("resource:food", structured["tags"])
+        self.assertIn("daily_action", structured["tags"])
+        self.assertIn("resource:food", structured["tags"])
+        self.assertIsNone(structured["causal_parent_id"])
+
+    def test_build_structured_event_data_for_reflection_links_to_parent_event(self):
+        structured = build_structured_event_data(
+            event_type="REFLECTION",
+            agent_id="demo-agent-0",
+            content="The river spirit punished those who fished at dawn.",
+            turn=13,
+            causal_parent_id=101,
+            entropy_level=0.8,
+        )
+
+        self.assertEqual(structured["actor"], "demo-agent-0")
+        self.assertEqual(structured["action"], "reflect")
+        self.assertEqual(structured["causal_parent_id"], 101)
+        self.assertGreaterEqual(structured["entropy_level"], 0.8)
+        self.assertIn("reflection", structured["tags"])
+        self.assertIn("myth", structured["tags"])
+
+    def test_simulation_event_to_dict_exposes_structured_fields(self):
+        row = {
+            "id": 7,
+            "turn": 14,
+            "agent_id": "demo-agent-1",
+            "event_type": "DAILY_ACTION",
+            "content": "Agent-1 shares food by the fire.",
+            "structured_data": {
+                "actor": "demo-agent-1",
+                "action": "share",
+                "location": "fire_pit",
+                "target": "Agent-2",
+                "cause": "social bond",
+                "effect": "belonging +0.12",
+                "tags": ["daily_action", "social"],
+                "importance": 0.7,
+                "entropy_level": 0.0,
+                "causal_parent_id": None,
+            },
+        }
+
+        payload = simulation_event_to_dict(row)
+
+        self.assertEqual(payload["id"], 7)
+        self.assertEqual(payload["actor"], "demo-agent-1")
+        self.assertEqual(payload["action"], "share")
+        self.assertEqual(payload["location"], "fire_pit")
+        self.assertEqual(payload["target"], "Agent-2")
+        self.assertEqual(payload["tags"], ["daily_action", "social"])
+        self.assertIn("structured", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / なぜこの変更が必要か
現在の `SimulationEvent` は `content` 中心で、後から timeline / replay / lore export を作る際に、行動・場所・対象・因果・結果を追跡しづらい状態でした。
Structured events を入れることで、文明の履歴を単なるテキストログではなく、分析可能なデータとして扱えるようにします。

## What / 何を変更したか
- `backend/event_schema.py` を追加し、イベントを構造化する共通ヘルパーを実装
  - `actor`
  - `action`
  - `target`
  - `location`
  - `cause`
  - `effect`
  - `outcome`
  - `tags`
  - `importance`
  - `entropy_level`
  - `causal_parent_id`
- `backend/models.py`
  - `SimulationEvent.structured_data` を追加
  - API 用の dict 変換を structured 対応に更新
- `backend/simulation.py`
  - daily action / reflection を structured data 付きで保存
  - reflection に causal parent を付けて、元の行動との関連を持たせた
- `backend/main.py`
  - `/api/history` が structured fields を返すよう更新
- tests
  - structured event schema と API serialization のテストを追加

Closes #7

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q backend tests`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
